### PR TITLE
Update pytorch to prevent CVE-2024-31583 and CVE-2024-31580

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/huggingface/transformers
-torch==1.12.0
+torch==2.4.0
 numpy==1.23.1
 pandas==1.4.3
 tqdm==4.64.0


### PR DESCRIPTION
# Why?
We need to secure this report against two recent CVE's in Pytorch 

[CVE-2024-31583](https://nvd.nist.gov/vuln/detail/CVE-2024-31583)

> "Pytorch before version v2.2.0 was discovered to contain a use-after-free vulnerability in torch/csrc/jit/mobile/interpreter.cpp."

[CVE-2024-31580](https://nvd.nist.gov/vuln/detail/CVE-2024-31580)

> "PyTorch before v2.2.0 was discovered to contain a heap buffer overflow vulnerability in the component /runtime/vararg_functions.cpp. This vulnerability allows attackers to cause a Denial of Service (DoS) via a crafted input."

# What?
Update to `torch=2.4.0`